### PR TITLE
Add extrinsic validation for multi-camera calibration

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,8 @@
 use std::io::Write;
 
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::types::RvecTvec;
 
 /// Serializes an object to a JSON file.
 pub fn object_to_json<T: Serialize>(output_path: &str, object: &T) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -583,10 +583,14 @@ pub fn validate_extrinsics(
                     find_relative_pose(rt_i, rt_j),
                     find_relative_pose(rt_j, rt_i),
                 ) {
-                    let error = pose_difference(&rt_i_j_expected, &measured_i_j);
+                    let measured_i_j_iso = measured_i_j.to_na_isometry3();
+                    let measured_j_i_iso = measured_j_i.to_na_isometry3();
+
+                    let error = pose_difference(&rt_i_j_expected, &measured_i_j_iso);
                     validation_errors.push((i, j, error));
 
-                    let error_inv = pose_difference(&rt_i_j_expected.inverse(), &measured_j_i);
+                    let error_inv =
+                        pose_difference(&rt_i_j_expected.inverse(), &measured_j_i_iso);
                     validation_errors.push((j, i, error_inv));
                 }
             }

--- a/tests/extrinsic_validation.rs
+++ b/tests/extrinsic_validation.rs
@@ -1,0 +1,126 @@
+use camera_intrinsic_calibration::types::RvecTvec;
+use camera_intrinsic_calibration::util::{analyze_extrinsic_outliers, validate_extrinsics};
+use camera_intrinsic_model::GenericModel;
+
+#[test]
+fn test_validate_extrinsics_no_errors() {
+    let intrinsics = vec![GenericModel::EUCM(camera_intrinsic_model::EUCM::new(
+        &[500.0, 500.0, 320.0, 240.0, 0.5],
+        640,
+        480,
+    ))];
+    let extrinsics = vec![RvecTvec::new(&[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0])];
+    let cam_rtvecs = vec![std::collections::HashMap::new()];
+
+    let errors = validate_extrinsics(&intrinsics, &extrinsics, &cam_rtvecs);
+    assert!(errors.is_empty());
+}
+
+#[test]
+fn test_validate_extrinsics_with_errors() {
+    let intrinsics = vec![
+        GenericModel::EUCM(camera_intrinsic_model::EUCM::new(
+            &[500.0, 500.0, 320.0, 240.0, 0.5],
+            640,
+            480,
+        )),
+        GenericModel::EUCM(camera_intrinsic_model::EUCM::new(
+            &[500.0, 500.0, 320.0, 240.0, 0.5],
+            640,
+            480,
+        )),
+    ];
+
+    let extrinsics = vec![
+        RvecTvec::new(&[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0]),
+        RvecTvec::new(&[0.1, 0.0, 0.0], &[0.5, 0.0, 0.0]),
+    ];
+
+    let mut cam_rtvecs = vec![
+        std::collections::HashMap::new(),
+        std::collections::HashMap::new(),
+    ];
+
+    // Add some frame data
+    cam_rtvecs[0].insert(0, RvecTvec::new(&[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0]));
+    cam_rtvecs[1].insert(0, RvecTvec::new(&[0.05, 0.0, 0.0], &[0.2, 0.0, 0.0]));
+
+    let errors = validate_extrinsics(&intrinsics, &extrinsics, &cam_rtvecs);
+    // Should detect some inconsistencies
+    assert!(!errors.is_empty());
+}
+
+#[test]
+fn test_analyze_extrinsic_outliers() {
+    let errors = vec![
+        (0, 1, 0.01),
+        (0, 1, 5.0), // Outlier
+        (1, 2, 0.02),
+    ];
+
+    let (outliers, recommendations) = analyze_extrinsic_outliers(&errors);
+
+    assert!(!outliers.is_empty());
+    assert!(outliers.contains(&(0, 1)));
+    assert!(!recommendations.is_empty());
+}
+
+#[test]
+fn test_analyze_extrinsic_no_outliers() {
+    let errors = vec![(0, 1, 0.01), (0, 1, 0.015), (1, 2, 0.02)];
+
+    let (outliers, recommendations) = analyze_extrinsic_outliers(&errors);
+
+    assert!(outliers.is_empty());
+    assert!(recommendations.is_empty());
+}
+
+#[test]
+fn test_pose_difference_calculation() {
+    use nalgebra as na;
+
+    let pose1 = na::Isometry3::from_parts(
+        na::Translation3::new(0.0, 0.0, 0.0),
+        na::UnitQuaternion::identity(),
+    );
+
+    let pose2 = na::Isometry3::from_parts(
+        na::Translation3::new(1.0, 0.0, 0.0),
+        na::UnitQuaternion::from_euler_angles(0.1, 0.0, 0.0),
+    );
+
+    // This tests the internal calculation, but since it's private,
+    // we test through the public API
+    let intrinsics = vec![
+        GenericModel::EUCM(camera_intrinsic_model::EUCM::new(
+            &[500.0, 500.0, 320.0, 240.0, 0.5],
+            640,
+            480,
+        )),
+        GenericModel::EUCM(camera_intrinsic_model::EUCM::new(
+            &[500.0, 500.0, 320.0, 240.0, 0.5],
+            640,
+            480,
+        )),
+    ];
+
+    let extrinsics = vec![
+        RvecTvec::new(&[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0]),
+        RvecTvec::new(&[0.1, 0.0, 0.0], &[1.0, 0.0, 0.0]),
+    ];
+
+    let mut cam_rtvecs = vec![
+        std::collections::HashMap::new(),
+        std::collections::HashMap::new(),
+    ];
+    cam_rtvecs[0].insert(0, RvecTvec::new(&[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0]));
+    cam_rtvecs[1].insert(0, RvecTvec::new(&[0.05, 0.0, 0.0], &[0.5, 0.0, 0.0]));
+
+    let errors = validate_extrinsics(&intrinsics, &extrinsics, &cam_rtvecs);
+    assert!(!errors.is_empty());
+    // Verify error values are reasonable
+    for (_, _, error) in errors {
+        assert!(error >= 0.0);
+        assert!(error.is_finite());
+    }
+}


### PR DESCRIPTION
Implements extrinsic validation enhancement for 'Multi-camera extrinsic' TODO. Adds consistency checks across camera pairs with pose difference metrics, providing confidence in multi-camera rig calibration accuracy.